### PR TITLE
Fix next button staying disabled due to a racing condition

### DIFF
--- a/view/frontend/templates/container.phtml
+++ b/view/frontend/templates/container.phtml
@@ -16,6 +16,7 @@
             var selectionDone = false;
 
             window.logitrailConfig = {
+                selectionDone: false,
                 containerId: 'logitrailHolder',
                 <?php echo $block->isTestMode()?'host: "http://checkout.test.logitrail.com",':''; ?>
                 bridgeUrl: '<?php echo $block->getUrl('logitrail/ajax/form'); ?>',
@@ -31,6 +32,7 @@
                         }
                     });
                     jQuery("#shipping-method-buttons-container").find(".button").prop("disabled", false);
+                    window.logitrailConfig.selectionDone = true;
                     selectionDone = true;
                 },
                 error: function(error) {

--- a/view/frontend/web/js/action/select-shipping-method.js
+++ b/view/frontend/web/js/action/select-shipping-method.js
@@ -11,7 +11,9 @@ define(
         return function (shippingMethod) {
             if(shippingMethod !== null) {
                 if (shippingMethod.carrier_code == 'logitrail') {
-                    $("#shipping-method-buttons-container").find(".button").prop("disabled", true);
+                    if(!window.logitrailConfig.selectionDone) {
+                        $("#shipping-method-buttons-container").find(".button").prop("disabled", true);
+                    }
                     $("#logitrailHolder").show();
                 } else {
                     $("#shipping-method-buttons-container").find(".button").prop("disabled", false);


### PR DESCRIPTION
In some cases the logitrail js would call the success function which
enables the next button before magento finished loading the next button itself